### PR TITLE
Topic/fswrapper

### DIFF
--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -364,15 +364,15 @@ class DeltaCacheStorage(object):
             raise NotConfigured
         self.storage = load_object(settings['DELTA_STORAGE'])(settings)
         self.cachedir = data_path(settings['HTTPCACHE_DIR'])
-        # Leave out the headers for now: they're an object, and they'll need to
-        # exist in their original form in order for copying/replacing responses
-        # to work properly.
-        self.to_delta = ['body', 'url']
+        # NOTE - Leave out the headers for now: Headers is a CaselessDict subclass
+        # (see scrapy.http.Headers), and we'll need to handle encoding and decoding
+        # deltas for contents.
+        self.to_delta = ['body']
         self._old_source_response = None
         self._new_source_response = None
 
     def open_spider(self, spider):
-        # Set up the old source response if it exists
+        # Set up the old source response if it exists.
         source_path = os.path.join(self.cachedir, '%s.delta_cache' % spider.name)
         if os.path.exists(source_path):
             with open(source_path, 'rb') as f:
@@ -380,7 +380,9 @@ class DeltaCacheStorage(object):
         self.storage.open_spider(spider)
 
     def close_spider(self, spider):
-        # Store the new source response if it exists
+        # Store the new source response if it exists. If all cache lookups are
+        # hits, self._new_source_response will be None, so we need to check if
+        # actually exists before overwriting the old source response.
         source_path = os.path.join(self.cachedir, '%s.delta_cache' % spider.name)
         if self._new_source_response:
             with open(source_path, 'wb') as f:
@@ -399,9 +401,7 @@ class DeltaCacheStorage(object):
         # For now, use the first response we get as the new source
         # TODO - how can we limit this check to only the first time
         # store_response is called?
-        # TODO - find a way to limit the new source to the old source.
-        # What conditions do we use for setting the response?
-        # - same urls?
+        # Ugly, but it works for testing.
         if not self._new_source_response:
             self._new_source_response = response.copy()
         delta_response = self._encode_response(response)
@@ -423,7 +423,10 @@ class DeltaCacheStorage(object):
             # Decode using the old source response
             source = getattr(self._old_source_response, x)
             delta = getattr(response, x)
-            buf_size = 1000000
+            # Use 1MB for buffer size for now.
+            # TODO - come up with a way to estimate buffer size, len(source) +
+            # len(delta) doesn't work well.
+            buf_size = 1048576
             result, restored_contents[x] = xdelta3.xd3_decode_memory(delta, source, buf_size)
         return response.replace(**restored_contents)
 

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import os
 import gzip
-import xdelta3
 from six.moves import cPickle as pickle
 from importlib import import_module
 from time import time
@@ -338,6 +337,7 @@ class DeltaFsCacheStorage(FilesystemCacheStorage):
     # TODO - store delta in a data structure along with original size so we can
     # use a more precise buffer for xdelta3, and pickle it before storing
     def __init__(self, settings):
+        import xdelta3
         super(DeltaFsCacheStorage, self).__init__(settings)
         source_body = settings['DELTA_SOURCE']
         with open(os.path.join(self.cachedir, source_body), 'rb') as f:
@@ -360,8 +360,10 @@ class DeltaFsCacheStorage(FilesystemCacheStorage):
 
 class DeltaCacheStorage(object):
     def __init__(self, settings):
+        import xdelta3
         if not settings.get('DELTA_STORAGE'):
             raise NotConfigured
+        self._xdelta3 = xdelta3
         self.storage = load_object(settings['DELTA_STORAGE'])(settings)
         self.cachedir = data_path(settings['HTTPCACHE_DIR'])
         # NOTE - Leave out the headers for now: Headers is a CaselessDict subclass
@@ -390,6 +392,9 @@ class DeltaCacheStorage(object):
         self.storage.close_spider(spider)
 
     def retrieve_response(self, spider, request):
+        # We only want to retrieve the cached response if we have some
+        # source response to use for decoding. Otherwise things would break
+        # if we tried to use DeltaStorage with an existing non-delta cache.
         cached_response = None
         if self._old_source_response:
             cached_response = self.storage.retrieve_response(spider, request)
@@ -414,7 +419,7 @@ class DeltaCacheStorage(object):
             source = getattr(self._new_source_response, x)
             target = getattr(response, x)
             buf_size = max(len(target), len(source)) * 2
-            result, delta_contents[x] = xdelta3.xd3_encode_memory(target, source, buf_size)
+            result, delta_contents[x] = self._xdelta3.xd3_encode_memory(target, source, buf_size)
         return response.replace(**delta_contents)
 
     def _decode_response(self, response):
@@ -427,7 +432,7 @@ class DeltaCacheStorage(object):
             # TODO - come up with a way to estimate buffer size, len(source) +
             # len(delta) doesn't work well.
             buf_size = 1048576
-            result, restored_contents[x] = xdelta3.xd3_decode_memory(delta, source, buf_size)
+            result, restored_contents[x] = self._xdelta3.xd3_decode_memory(delta, source, buf_size)
         return response.replace(**restored_contents)
 
 class LeveldbCacheStorage(object):

--- a/scrapy/extensions/httpcache.py
+++ b/scrapy/extensions/httpcache.py
@@ -13,6 +13,7 @@ from scrapy.responsetypes import responsetypes
 from scrapy.utils.request import request_fingerprint
 from scrapy.utils.project import data_path
 from scrapy.utils.httpobj import urlparse_cached
+from scrapy.utils.misc import load_object
 
 
 class DummyPolicy(object):
@@ -305,18 +306,18 @@ class FilesystemCacheStorage(object):
             'response_url': response.url,
             'timestamp': time(),
         }
-        #with self._open(os.path.join(rpath, 'meta'), 'wb') as f:
-        #    f.write(repr(metadata))
-        #with self._open(os.path.join(rpath, 'pickled_meta'), 'wb') as f:
-        #    pickle.dump(metadata, f, protocol=2)
-        #with self._open(os.path.join(rpath, 'response_headers'), 'wb') as f:
-        #    f.write(headers_dict_to_raw(response.headers))
+        with self._open(os.path.join(rpath, 'meta'), 'wb') as f:
+            f.write(repr(metadata))
+        with self._open(os.path.join(rpath, 'pickled_meta'), 'wb') as f:
+            pickle.dump(metadata, f, protocol=2)
+        with self._open(os.path.join(rpath, 'response_headers'), 'wb') as f:
+            f.write(headers_dict_to_raw(response.headers))
         with self._open(os.path.join(rpath, 'response_body'), 'wb') as f:
             f.write(response.body)
-        #with self._open(os.path.join(rpath, 'request_headers'), 'wb') as f:
-        #    f.write(headers_dict_to_raw(request.headers))
-        #with self._open(os.path.join(rpath, 'request_body'), 'wb') as f:
-        #    f.write(request.body)
+        with self._open(os.path.join(rpath, 'request_headers'), 'wb') as f:
+            f.write(headers_dict_to_raw(request.headers))
+        with self._open(os.path.join(rpath, 'request_body'), 'wb') as f:
+            f.write(request.body)
 
     def _get_request_path(self, spider, request):
         key = request_fingerprint(request)
@@ -356,6 +357,75 @@ class DeltaFsCacheStorage(FilesystemCacheStorage):
         result, delta = xdelta3.xd3_encode_memory(response.body, self._source_body, max_delta_size)
         delta_response = response.replace(body = delta)
         super(DeltaFsCacheStorage, self).store_response(spider, request, delta_response)
+
+class DeltaCacheStorage(object):
+    def __init__(self, settings):
+        if not settings.get('DELTA_STORAGE'):
+            raise NotConfigured
+        self.storage = load_object(settings['DELTA_STORAGE'])(settings)
+        self.cachedir = data_path(settings['HTTPCACHE_DIR'])
+        # Leave out the headers for now: they're an object, and they'll need to
+        # exist in their original form in order for copying/replacing responses
+        # to work properly.
+        self.to_delta = ['body', 'url']
+        self._old_source_response = None
+        self._new_source_response = None
+
+    def open_spider(self, spider):
+        # Set up the old source response if it exists
+        source_path = os.path.join(self.cachedir, '%s.delta_cache' % spider.name)
+        if os.path.exists(source_path):
+            with open(source_path, 'rb') as f:
+                self._old_source_response = pickle.load(f)
+        self.storage.open_spider(spider)
+
+    def close_spider(self, spider):
+        # Store the new source response if it exists
+        source_path = os.path.join(self.cachedir, '%s.delta_cache' % spider.name)
+        if self._new_source_response:
+            with open(source_path, 'wb') as f:
+                pickle.dump(self._new_source_response, f, protocol=2)
+        self.storage.close_spider(spider)
+
+    def retrieve_response(self, spider, request):
+        cached_response = None
+        if self._old_source_response:
+            cached_response = self.storage.retrieve_response(spider, request)
+        if cached_response:
+            return self._decode_response(cached_response)
+        return cached_response
+
+    def store_response(self, spider, request, response):
+        # For now, use the first response we get as the new source
+        # TODO - how can we limit this check to only the first time
+        # store_response is called?
+        # TODO - find a way to limit the new source to the old source.
+        # What conditions do we use for setting the response?
+        # - same urls?
+        if not self._new_source_response:
+            self._new_source_response = response.copy()
+        delta_response = self._encode_response(response)
+        self.storage.store_response(spider, request, delta_response)
+
+    def _encode_response(self, response):
+        delta_contents = {}
+        for x in self.to_delta:
+            # Encode using the new source response
+            source = getattr(self._new_source_response, x)
+            target = getattr(response, x)
+            buf_size = max(len(target), len(source)) * 2
+            result, delta_contents[x] = xdelta3.xd3_encode_memory(target, source, buf_size)
+        return response.replace(**delta_contents)
+
+    def _decode_response(self, response):
+        restored_contents = {}
+        for x in self.to_delta:
+            # Decode using the old source response
+            source = getattr(self._old_source_response, x)
+            delta = getattr(response, x)
+            buf_size = 1000000
+            result, restored_contents[x] = xdelta3.xd3_decode_memory(delta, source, buf_size)
+        return response.replace(**restored_contents)
 
 class LeveldbCacheStorage(object):
 


### PR DESCRIPTION
This adds a new DeltaCacheStorage class. Note that this requires setting the following in a spider's `settings.py`:

```
HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.DeltaCacheStorage'
DELTA_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
```

DELTA_STORAGE is a new config setting that can be any other classpath for the HTTPCache storage backend.
